### PR TITLE
Clarify that Context parameters should come first

### DIFF
--- a/cppguide.html
+++ b/cppguide.html
@@ -1720,6 +1720,17 @@ both input and output (often classes/structs) muddy the
 waters, and, as always, consistency with related
 functions may require you to bend the rule.</p>
 
+<p class="clarification drake">
+In particular, the ubiquitous Drake <code>Context</code>
+object, when mutable, is typically an in/out parameter as
+mentioned above. We prefer to have it consistently
+first, where it can be mostly ignored and does not
+interfere with the ability to have default parameters
+at the end of the parameter list. So a
+<code>Context</code> parameter should come first, and 
+be declared either <code>const Context&</code>, or
+<code>Context*</code> if it is mutable.</p>
+
 </div> 
 
 <h3 id="Write_Short_Functions">Write Short Functions</h3>

--- a/include/styleguide.css
+++ b/include/styleguide.css
@@ -246,6 +246,13 @@ address {
   margin-bottom: 1em;
 }
 
+.clarification:before {
+  content: "Clarification: ";
+  font-weight: bold;
+  display: block;
+  margin-bottom: 1em;
+}
+
 .exception:before {
   content: "Exception: ";
   font-weight: bold;


### PR DESCRIPTION
Adds a clarification to the style guide that Context parameters should come first in Drake API methods, even if mutable (where they are normally in/out).

This came up in review of RobotLocomotion/drake#7186, see [comment](https://reviewable.io/reviews/robotlocomotion/drake/7186#-Kw1iX7RmFV75OjbyFo7).

We already have methods in `master` using this convention. There will be a lot more as MultibodyTree gets fleshed out. I did not spot any cases where existing methods would have to change.

+@amcastro-tri for feature review
+@ggould-tri for platform review (per rotation) and any other interested platform reviewers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/styleguide/2)
<!-- Reviewable:end -->
