### PR TITLE
Allow authorship comments?

### DIFF
--- a/cppguide.html
+++ b/cppguide.html
@@ -5265,6 +5265,58 @@ new interface point.</p>
 
 </div> 
 
+<h3 id="Authorship_Comments">
+<span class="drake">Authorship Comments</span></h3>
+
+<span class="drake">
+<div class="summary">
+<p>Although there is no need for authorship comments in
+Drake, if you feel strongly that you want to sign your
+work you may do so as specified below.</p>
+</div>
+
+<div class="stylebody">
+
+<p>Drake is a large-team effort in which many programmers
+typically contribute to the same block of code, with no
+particular person claiming ownership. That is reflected
+in the alphabetized Drake
+<a href="https://drake.mit.edu/credits">Credits Page</a>,
+and you should definitely add yourself to that list. In
+addition, git maintains a history of all code modifications,
+and <code>git annotate</code> or <code>git blame</code>
+can be used to find out who did what when. So in most cases
+there is no need to add authorship details to the code.
+However, if you are particularly proud of a significant
+contribution, you can sign your beautiful creation
+with a Doxygen-formatted comment. Then your name
+will appear in the source code and in the generated
+Doxygen documentation.</p>
+
+<p>IMPORTANT NOTE: Copyright is a legal concept separate
+from authorship. Listing yourself as an author
+does <em>not</em> automatically confer copyright to you.</p>
+
+<p>Code-signing should be formatted like this example:<pre>
+@authors Jane Doe (2016-2017) Original author.
+@authors Joe Schmoe (2018) Made thread-safe.
+@authors Drake team (see https://drake.mit.edu/credits).
+</pre>
+
+<p>The last line is mandatory, all the fields are required,
+and new authors should normally be added below existing ones.
+In content that is not processed by Doxygen, such as XML
+or code that appears only in <code>.cc</code> files, please
+use <code>@authors</code> and format the same way for
+uniformity, unless there is a good reason to do otherwise.</p>
+
+<p>If you submit a PR that affects authorship, you are
+responsible for updating the author list as appropriate. For
+example, if your contribution effectively removes an earlier
+author's contributions, you should remove that author.</p>
+</div>
+</span>
+
 <h2 id="Formatting">Formatting</h2>
 
 <p>Coding style and formatting are pretty arbitrary, but a


### PR DESCRIPTION
This is a proposal to _allow_ Drake programmers who would like to do so to sign their significant contributions, so that their names appear in the source code and Doxygen. Note that there is already a Drake [Credits page](https://drake.mit.edu/credits) and of course git remembers everything, so this is entirely optional and not usually needed.

Comments on this proposal are welcome, and sign-on from other platform reviewers is required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/styleguide/11)
<!-- Reviewable:end -->
