### PR TITLE
gtest: Forbid death tests for most cases

### DIFF
--- a/cppguide.html
+++ b/cppguide.html
@@ -2452,6 +2452,14 @@ you can download
 use
 <code>GTEST_TEST(Group, Name)</code> instead of <code>TEST(Group,
 Name)</code>. (<a href="https://github.com/RobotLocomotion/drake/issues/2181">#2181</a>)</p>
+<p>Do not use
+<a href="https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#death-tests">death tests</a>
+(<code>EXPECT_DEATH</code>, <code>ASSERT_DEATH</code>, ...).
+Death tests are difficult to implement and maintain correctly, and there is
+almost always a better formulation for the implementation and test that does
+not involve death tests.  Death should almost never be part of a method
+contract and so it is not necessary to test it.
+</p> 
 </div>
 
 </div>


### PR DESCRIPTION
I'd like to clearly forbidd a testing regime that is error prone and wastes everyone's time, so that we don't have to re-debate its use in each instance.

I believe this is consistent with current `master` practice, and our ongoing philosophy.  Current uses of death tests in Drake are:
- Unit test for `DRAKE_ASSERT` / `DRAKE_DEMAND`.
- Unit test for `limit_malloc` (which uses C ABIs).

Preview [is here](http://htmlpreview.github.io/?https://raw.githubusercontent.com/jwnimmer-tri/styleguide/cdb204e974c242846be19fbd3b48dde97b33457b/cppguide.html#GTEST_specific).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/styleguide/20)
<!-- Reviewable:end -->
