### PR TITLE
cpplint: Add more build/include checks

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -5376,6 +5376,8 @@ def ExpectingFunctionArgs(clean_lines, linenum):
 
 
 _HEADERS_CONTAINING_TEMPLATES = (
+    ('<any>', ('any',)),
+    ('<array>', ('array',)),
     ('<deque>', ('deque',)),
     ('<functional>', ('unary_function', 'binary_function',
                       'plus', 'minus', 'multiplies', 'divides', 'modulus',
@@ -5399,6 +5401,7 @@ _HEADERS_CONTAINING_TEMPLATES = (
     ('<map>', ('map', 'multimap',)),
     ('<memory>', ('allocator', 'make_shared', 'make_unique', 'shared_ptr',
                   'unique_ptr', 'weak_ptr')),
+    ('<optional>', ('optional',)),
     ('<queue>', ('queue', 'priority_queue',)),
     ('<set>', ('set', 'multiset',)),
     ('<stack>', ('stack',)),
@@ -5407,6 +5410,7 @@ _HEADERS_CONTAINING_TEMPLATES = (
     ('<unordered_map>', ('unordered_map', 'unordered_multimap')),
     ('<unordered_set>', ('unordered_set', 'unordered_multiset')),
     ('<utility>', ('pair',)),
+    ('<variant>', ('variant',)),
     ('<vector>', ('vector',)),
 
     # gcc extensions.


### PR DESCRIPTION
Add patterns for `<any>`, `<array>`, `<optional>`, and `<variant>`.

See https://github.com/RobotLocomotion/drake/pull/12705 for consequences.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/styleguide/24)
<!-- Reviewable:end -->
