### PR TITLE
Remove Drake exception allowing for -inl.h files

### DIFF
--- a/cppguide.html
+++ b/cppguide.html
@@ -213,10 +213,6 @@ pitfalls of using header files.</p>
 <p>Header files should be self-contained (compile on their own) and
 end in <code>.h</code>.  Non-header files that are meant for inclusion
 should end in <code>.inc</code> and be used sparingly.</p>
-<p class="exception drake">
-  The Self-contained headers rule may be disobeyed when implementing
-  the <a href="http://drake.mit.edu/cxx_inl.html#cxx-inl-files">C++ *-inl.h
-  files pattern</a> in its exact form.</p>
 </div> 
 
 <div class="stylebody">


### PR DESCRIPTION
We typically no longer allow these files.

There are currently four remaining uses in Drake:
- The integrators in `systems/analysis`; to be removed in https://github.com/RobotLocomotion/drake/pull/12657.
- Two integrator-related `examples`, to be removed by https://github.com/RobotLocomotion/drake/pull/12710.
- One use for `RigidBodyTree`.  I figure we leave it alone under a grandfather clause.
- One use for `MultibodyTree`.  As with anything in GSG we can sidestep the rules in dire need.  I think MbT's use counts as such.

Drake PR is https://github.com/RobotLocomotion/drake/pull/12711.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/styleguide/25)
<!-- Reviewable:end -->
