### PR TITLE
Add tests for array, optional and variant

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -5376,7 +5376,6 @@ def ExpectingFunctionArgs(clean_lines, linenum):
 
 
 _HEADERS_CONTAINING_TEMPLATES = (
-    ('<any>', ('any',)),
     ('<array>', ('array',)),
     ('<deque>', ('deque',)),
     ('<functional>', ('unary_function', 'binary_function',

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -1079,6 +1079,39 @@ class CpplintTest(CpplintTestBase):
         """,
         'Add #include <utility> for swap'
         '  [build/include_what_you_use] [4]')
+    self.TestIncludeWhatYouUse(
+        """#include <array>
+           std::array<int, 10> A;
+        """,
+        '')
+    self.TestIncludeWhatYouUse(
+        """#include <string>
+           std::array<int, 10> A;
+        """,
+        'Add #include <array> for array<>'
+        '  [build/include_what_you_use] [4]')
+    self.TestIncludeWhatYouUse(
+        """#include <optional>
+           std::optional<int> A;
+        """,
+        '')
+    self.TestIncludeWhatYouUse(
+        """#include <string>
+           std::optional<int> A;
+        """,
+        'Add #include <optional> for optional<>'
+        '  [build/include_what_you_use] [4]')
+    self.TestIncludeWhatYouUse(
+        """#include <variant>
+           std::variant<int, float> A;
+        """,
+        '')
+    self.TestIncludeWhatYouUse(
+        """#include <string>
+           std::variant<int, float> A;
+        """,
+        'Add #include <variant> for variant<>'
+        '  [build/include_what_you_use] [4]')
 
     # Test the UpdateIncludeState code path.
     mock_header_contents = ['#include "blah/foo.h"', '#include "blah/bar.h"']


### PR DESCRIPTION
- It seems like `any` is non-templated: https://en.cppreference.com/w/cpp/utility/any
- Adding the following code fails:
  ```
    self.TestIncludeWhatYouUse(
        """#include <string>
           std::any A;
        """,
        'Add #include <any> for any'
        '  [build/include_what_you_use] [4]')
  ```
- We could perhaps add partial IWYU ability to cpplint for headers like `any`, `mutex` etc. with the following code (please have a look at the regex and I could PR it if you'd like):
  https://github.com/m-chaturvedi/styleguide/commit/d29faac148f21f32a49d3449a650f2148cec74e4

- With some hacking with `cpplint.py`, we had found the following list of headers from the standard library from different C++ standards which are in drake but not in Google's cpplint (`_HEADERS_CONTAINING_TEMPLATES` variable):
https://gist.github.com/m-chaturvedi/69fab1f492aa1f386a9b4aa4c8c3ca40

- AFAIK `any` is not used in drake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/styleguide/26)
<!-- Reviewable:end -->
