### PR TITLE
cpplint: Enforce line_length on C-style comments

### DIFF
--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -361,10 +361,21 @@ class CpplintTest(CpplintTestBase):
     lines = ['a', 'b', ' c */']
     self.assertEquals(2, cpplint.FindNextMultiLineCommentEnd(lines, 0))
 
-  def testRemoveMultiLineCommentsFromRange(self):
-    lines = ['a', '  /* comment ', ' * still comment', ' comment */   ', 'b']
-    cpplint.RemoveMultiLineCommentsFromRange(lines, 1, 4)
-    self.assertEquals(['a', '/**/', '/**/', '/**/', 'b'], lines)
+  def testReplaceMultiLineCommentsInRange(self):
+    lines = [
+      'a',
+      '  /* comment ',
+      '  * still comment',
+      '  comment */',
+      'b']
+    cpplint.ReplaceMultiLineCommentsInRange(None, lines, 1, 4, None)
+    self.assertEquals([
+      'a',
+      '  // comment ',
+      '  // * sticomment',
+      '  // comt ./',
+      'b'],
+      lines)
 
   def testSpacesAtEndOfLine(self):
     self.TestLint(
@@ -513,9 +524,7 @@ class CpplintTest(CpplintTestBase):
                                '// NOLINT(build/header_guard)',
                                '// NOLINT(build/pragma_once)',
                                'int64 a = (uint64) 65;',
-                               '/* Prevent warnings about the modeline',
-                               modeline,
-                               '*/',
+                               '// ' + modeline,
                                ''],
                               error_collector)
       self.assertEquals('', error_collector.Results())
@@ -1317,7 +1326,7 @@ class CpplintTest(CpplintTestBase):
             class Foo {
             Foo(int f);  // should cause a lint warning in code
             }
-            */ """,
+            */""",
         '')
     self.TestMultiLineLint(
         r"""/* int a = 0; multi-liner


### PR DESCRIPTION
Prior to this patch, cpplint ignores C-style comments entirely, so in Drake they had trailing whitespace, overly long lines, etc.

Note that this adds false positives for `whitespace/todo` when TODO is used within a C-style comment.  We don't care, because we have that warning disabled in Drake.

Tested vs Drake in RobotLocomotion/drake#13804.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/styleguide/31)
<!-- Reviewable:end -->
