### PR TITLE
Fix false positive cpplint

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -3884,11 +3884,11 @@ def CheckBraces(filename, clean_lines, linenum, error):
   # its line, and the line after that should have an indent level equal to or
   # lower than the if. We also check for ambiguous if/else nesting without
   # braces.
-  if_else_match = Search(r'\b(if\s*\(|else\b)', line)
+  if_else_match = Search(r'\b(if\s*(|constexpr)\s*\(|else\b)', line)
   if if_else_match and not Match(r'\s*#', line):
     if_indent = GetIndentLevel(line)
     endline, endlinenum, endpos = line, linenum, if_else_match.end()
-    if_match = Search(r'\bif\s*\(', line)
+    if_match = Search(r'\bif\s*(|constexpr)\s*\(', line)
     if if_match:
       # This could be a multiline if condition, so find the end first.
       pos = if_match.end() - 1

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -3710,6 +3710,21 @@ class CpplintTest(CpplintTestBase):
         '  [readability/braces] [4]')
     self.TestMultiLineLint(
         """
+        if constexpr (foo)
+          goto fail;
+          goto fail;""",
+        'If/else bodies with multiple statements require braces'
+        '  [readability/braces] [4]')
+    self.TestMultiLineLint(
+        """
+        if constexpr (foo) {
+          bar;
+        } else if constexpr (baz) {
+          qux;
+        }""",
+        '')
+    self.TestMultiLineLint(
+        """
         if (foo)
           if (bar)
             baz;


### PR DESCRIPTION
Fix a cpplint false positive readability/braces error where the linter fails to find the opening parenthesis after `if constexpr` because the parser doesn't consider `constexpr`.

This change was adapted from https://github.com/cpplint/cpplint/pull/136

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/styleguide/47)
<!-- Reviewable:end -->
