### PR TITLE
[cpplint] Fully prescribe closing namespace comments

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -2441,33 +2441,19 @@ class _NamespaceInfo(_BlockInfo):
     # Note that we accept C style "/* */" comments for terminating
     # namespaces, so that code that terminate namespaces inside
     # preprocessor macros can be cpplint clean.
-    #
-    # We also accept stuff like "// end of namespace <name>." with the
-    # period at the end.
-    #
-    # Besides these, we don't accept anything else, otherwise we might
-    # get false negatives when existing comment is a substring of the
-    # expected namespace.
     if self.name:
       # Named namespace
-      if not Match((r'^\s*};*\s*(//|/\*).*\bnamespace\s+' +
-                    re.escape(self.name) + r'[\*/\.\\\s]*$'),
+      if not Match((r'^\s*}*\s*(//|/\*)\s*\bnamespace\s+' +
+                    re.escape(self.name) + r'[\*/\\\s]*$'),
                    line):
         error(filename, linenum, 'readability/namespace', 5,
               'Namespace should be terminated with "// namespace %s"' %
               self.name)
     else:
       # Anonymous namespace
-      if not Match(r'^\s*};*\s*(//|/\*).*\bnamespace[\*/\.\\\s]*$', line):
-        # If "// namespace anonymous" or "// anonymous namespace (more text)",
-        # mention "// anonymous namespace" as an acceptable form
-        if Match(r'^\s*}.*\b(namespace anonymous|anonymous namespace)\b', line):
-          error(filename, linenum, 'readability/namespace', 5,
-                'Anonymous namespace should be terminated with "// namespace"'
-                ' or "// anonymous namespace"')
-        else:
-          error(filename, linenum, 'readability/namespace', 5,
-                'Anonymous namespace should be terminated with "// namespace"')
+      if not Match(r'^\s*}*\s*(//|/\*)\s*\bnamespace[\*/\\\s]*$', line):
+        error(filename, linenum, 'readability/namespace', 5,
+              'Anonymous namespace should be terminated with "// namespace"')
 
 
 class _PreprocessorInfo(object):


### PR DESCRIPTION
Specifically:
- Do not allow "anonymous" as the namespace's pseudo-name.
- Do not allow any extra words like "// end drake".
- Do not allow spurious periods.
- Do not allow spurious semicolons.

This means that the "suggested fix" by cpplint is actually the _only_ fix.  Having only one way to format it simplifies the life of authors and reviewers.

See https://github.com/RobotLocomotion/drake/pull/19270 for the new lint this change uncovers.

See https://github.com/RobotLocomotion/drake/pull/19240#issuecomment-1520833890 for the developer confusion (and reviewer burden) this will avoid in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/styleguide/52)
<!-- Reviewable:end -->
